### PR TITLE
Cocoapods implementation

### DIFF
--- a/CHWManagement/Sources/Builders/CfLogChwModuleEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogChwModuleEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 25/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogChwModuleEvent {

--- a/CHWManagement/Sources/Builders/CfLogCounselingEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogCounselingEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 21/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogCounselingEvent {

--- a/CHWManagement/Sources/Builders/CfLogInvestigationEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogInvestigationEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 26/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 /**

--- a/CHWManagement/Sources/Builders/CfLogLifestyleEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogLifestyleEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 26/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogLifestyleEvent {

--- a/CHWManagement/Sources/Builders/CfLogPrescriptionEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogPrescriptionEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogPrescriptionEvent {

--- a/CHWManagement/Sources/Builders/CfLogSubmitAssessmentEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogSubmitAssessmentEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogSubmitAssessmentEvent {

--- a/CHWManagement/Sources/Builders/CfLogSubmitEnrolmentEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogSubmitEnrolmentEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogSubmitEnrolmentEvent {

--- a/CHWManagement/Sources/Builders/CfLogSubmitMedicalReviewEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogSubmitMedicalReviewEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogSubmitMedicalReviewEvent {

--- a/CHWManagement/Sources/Builders/CfLogSubmitScreeningEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogSubmitScreeningEvent.swift
@@ -4,7 +4,9 @@
 //
 //  Created by khushbu on 03/11/23.
 //
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogSubmitScreeningEvent {

--- a/CHWManagement/Sources/Builders/CfLogTreatmentPlanEvent.swift
+++ b/CHWManagement/Sources/Builders/CfLogTreatmentPlanEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogTreatmentPlanEvent {

--- a/CHWManagement/Sources/Catalog/CfChwCatalog.swift
+++ b/CHWManagement/Sources/Catalog/CfChwCatalog.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum CfChwCatalog {

--- a/CHWManagement/Sources/Constants/ChwConstants.swift
+++ b/CHWManagement/Sources/Constants/ChwConstants.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 25/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 enum ChwConstants {

--- a/CHWManagement/Sources/Enums/ChwModuleType.swift
+++ b/CHWManagement/Sources/Enums/ChwModuleType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 26/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ChwModuleType: String, EnumComposable {

--- a/CHWManagement/Sources/Enums/ChwSiteType.swift
+++ b/CHWManagement/Sources/Enums/ChwSiteType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ChwSiteType: String, EnumComposable {

--- a/CHWManagement/Sources/Enums/CounselingType.swift
+++ b/CHWManagement/Sources/Enums/CounselingType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 21/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum CounselingType: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Enums/DiagnosisSymptomType.swift
+++ b/CHWManagement/Sources/Enums/DiagnosisSymptomType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum DiagnosisSymptomType: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Enums/DiagnosisType.swift
+++ b/CHWManagement/Sources/Enums/DiagnosisType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum DiagnosisType: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Enums/ItemAction.swift
+++ b/CHWManagement/Sources/Enums/ItemAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 26/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ItemAction: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Enums/PatientStatusValueType.swift
+++ b/CHWManagement/Sources/Enums/PatientStatusValueType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 04/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PatientStatusValueType: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Enums/PrescriptionItemFrequency.swift
+++ b/CHWManagement/Sources/Enums/PrescriptionItemFrequency.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PrescriptionItemFrequency: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Enums/PrescriptionItemType.swift
+++ b/CHWManagement/Sources/Enums/PrescriptionItemType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 03/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 import Foundation

--- a/CHWManagement/Sources/Enums/ReviewSummaryItem.swift
+++ b/CHWManagement/Sources/Enums/ReviewSummaryItem.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ReviewSummaryItem: String, EnumComposable {

--- a/CHWManagement/Sources/Enums/ScreeningType.swift
+++ b/CHWManagement/Sources/Enums/ScreeningType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ScreeningType: String, EnumComposable {

--- a/CHWManagement/Sources/Enums/TreatmentType.swift
+++ b/CHWManagement/Sources/Enums/TreatmentType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 04/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum TreatmentType: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Models/Iteam_Objects/TreatmentFrequency.swift
+++ b/CHWManagement/Sources/Models/Iteam_Objects/TreatmentFrequency.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 04/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum TreatmentFrequency: String, Codable, EnumComposable {

--- a/CHWManagement/Sources/Utils/CFSetup+CHW.swift
+++ b/CHWManagement/Sources/Utils/CFSetup+CHW.swift
@@ -1,11 +1,13 @@
 //
-//  CFSetup+Extension.swift
+//  CFSetup+CHW.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension CFSetup {

--- a/CHWManagement/Sources/Utils/CatalogAPIHandler+CHW.swift
+++ b/CHWManagement/Sources/Utils/CatalogAPIHandler+CHW.swift
@@ -1,11 +1,13 @@
 //
-//  CatalogAPIHandler.swift
+//  CatalogAPIHandler+CHW.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension CatalogAPIHandler {

--- a/CHWManagement/Sources/Utils/ChwEventValidation.swift
+++ b/CHWManagement/Sources/Utils/ChwEventValidation.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 10/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 enum ChwEventValidation {

--- a/CHWManagement/Sources/Utils/MMKVHelper+CHW.swift
+++ b/CHWManagement/Sources/Utils/MMKVHelper+CHW.swift
@@ -1,11 +1,13 @@
 //
-//  MMKVHelper+Extension.swift
+//  MMKVHelper+CHW.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension MMKVHelper {

--- a/CausalFoundrySDK.podspec
+++ b/CausalFoundrySDK.podspec
@@ -1,0 +1,37 @@
+#
+#  Be sure to run `pod lib lint CausalFoundrySDK.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+  s.name         = "CausalFoundrySDK"
+  s.version      = "0.0.1"
+  s.summary      = "CausalFoundry SDK"
+  s.description  = "CausalFoundry SDK Description"
+  s.homepage     = "https://github.com/causalfoundry/ios-sdk"
+  s.license      = { :type => 'Apache License, Version 2.0', :text => <<-LICENSE
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    LICENSE
+  }
+  s.author       = { "Developer" => "moiz@causalfoundry.ai" }
+  s.platform     = :ios, "13.0"
+  s.source       = { :git => "https://github.com/causalfoundry/ios-sdk", :branch => 'develop' }
+  s.source_files =  "CHWManagement/Sources/**/*.swift", "Core/Sources/**/*.swift", "E_Commerce/Sources/**/*.swift", "E_Learning/Sources/**/*.swift", "Frameworks/**/*.xcframework", "Loyalty/Sources/**/*.swift", "Payments/Sources/**/*.swift"
+  s.exclude_files = "Package.swift", "build.sh", "CHWManagement/Tests", "Core/Tests", "E_Commerce/Tests", "E_Learning/Tests", "Loyalty/Tests", "Payments/Testst"
+  s.requires_arc = true
+  s.swift_version= '5.4'
+  s.vendored_frameworks = 'Frameworks/MMKV.xcframework'
+end

--- a/Core/Sources/Database/Extnesions/MMKVHelper+Core.swift
+++ b/Core/Sources/Database/Extnesions/MMKVHelper+Core.swift
@@ -1,5 +1,5 @@
 //
-//  MMKVHelper+Extension.swift
+//  MMKVHelper+Core.swift
 //
 //
 //  Created by khushbu on 08/11/23.

--- a/Core/Sources/Nudge listener/NudgeUtils.swift
+++ b/Core/Sources/Nudge listener/NudgeUtils.swift
@@ -102,10 +102,12 @@ enum NudgeUtils {
     }
 
     private static func validateAndProvideItemPairString(inputString: String, nudgeObject: BackendNudgeMainObject) -> String {
+        /*
         guard let itemPairCfg = nudgeObject.nd.message?.tmplCFG?.itemPairCFG else {
             ExceptionManager.throwInvalidNudgeException(message: "Invalid tmpl_cfg.item_pair_cfg provided", nudgeObject: nudgeObject.prettyJSON)
             return ""
         }
+        */
         guard let extra = nudgeObject.extra else {
             ExceptionManager.throwInvalidNudgeException(message: "Invalid extra provided", nudgeObject: nudgeObject.prettyJSON)
             return ""

--- a/E_Commerce/Sources/Builders/CfLogCancelCheckoutEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogCancelCheckoutEvent.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogCancelCheckoutEvent {

--- a/E_Commerce/Sources/Builders/CfLogCartEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogCartEvent.swift
@@ -4,7 +4,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogCartEvent {

--- a/E_Commerce/Sources/Builders/CfLogCheckoutEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogCheckoutEvent.swift
@@ -1,4 +1,6 @@
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogCheckoutEvent {

--- a/E_Commerce/Sources/Builders/CfLogDeliveryEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogDeliveryEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 29/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogDeliveryEvent {

--- a/E_Commerce/Sources/Builders/CfLogItemEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogItemEvent.swift
@@ -5,7 +5,9 @@
 //  Created by moizhassankh on 07/12/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogItemEvent {
@@ -31,7 +33,7 @@ public class CfLogItemEvent {
      * Below is the method for the enum based approach.
      */
     @discardableResult
-    public func setItemAction(itemAction: ItemAction) -> CfLogItemEvent {
+    public func setItemAction(itemAction: EComItemAction) -> CfLogItemEvent {
         itemActionValue = itemAction.rawValue
         return self
     }
@@ -47,10 +49,10 @@ public class CfLogItemEvent {
      */
     @discardableResult
     public func setItemAction(itemActionValue: String) -> CfLogItemEvent {
-        if CoreConstants.shared.enumContains(ItemAction.self, name: itemActionValue) {
+        if CoreConstants.shared.enumContains(EComItemAction.self, name: itemActionValue) {
             self.itemActionValue = itemActionValue
         } else {
-            ExceptionManager.throwEnumException(eventType: EComEventType.item.rawValue, className: String(describing: ItemAction.self))
+            ExceptionManager.throwEnumException(eventType: EComEventType.item.rawValue, className: String(describing: EComItemAction.self))
         }
         return self
     }
@@ -195,7 +197,7 @@ public class CfLogItemEvent {
 
     public func build() {
         if itemActionValue.isEmpty {
-            ExceptionManager.throwIsRequiredException(eventType: EComEventType.item.rawValue, elementName: String(describing: ItemAction.self))
+            ExceptionManager.throwIsRequiredException(eventType: EComEventType.item.rawValue, elementName: String(describing: EComItemAction.self))
             return
         } else {
             let itemViewObject = ViewItemObject(action:itemActionValue, item: itemObject)

--- a/E_Commerce/Sources/Builders/CfLogItemReportEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogItemReportEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogItemReportEvent {

--- a/E_Commerce/Sources/Builders/CfLogItemRequestEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogItemRequestEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogItemRequestEvent {

--- a/E_Commerce/Sources/Builders/CfLogItemVerificationEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogItemVerificationEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogItemVerificationEvent {

--- a/E_Commerce/Sources/Builders/CfLogScheduleDeliveryEvent.swift
+++ b/E_Commerce/Sources/Builders/CfLogScheduleDeliveryEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogScheduleDeliveryEvent {

--- a/E_Commerce/Sources/Catalog/CfEComCatalog.swift
+++ b/E_Commerce/Sources/Catalog/CfEComCatalog.swift
@@ -5,7 +5,9 @@
 //  Created by moizhassankh on 07/12/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfEComCatalog {

--- a/E_Commerce/Sources/Constants/ECommerceConstants.swift
+++ b/E_Commerce/Sources/Constants/ECommerceConstants.swift
@@ -5,7 +5,9 @@
 //  Created by moizhassankh on 07/12/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ECommerceConstants {

--- a/E_Commerce/Sources/Utility/CFSetup+Core.swift
+++ b/E_Commerce/Sources/Utility/CFSetup+Core.swift
@@ -1,11 +1,13 @@
 //
-//  CFSetup+Extension.swift
+//  CFSetup+Core.swift
 //
 //
 //  Created by khushbu on 29/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension CFSetup {

--- a/E_Commerce/Sources/Utility/CatalogAPIHandler+E-Commerce.swift
+++ b/E_Commerce/Sources/Utility/CatalogAPIHandler+E-Commerce.swift
@@ -1,11 +1,13 @@
 //
-//  CatalogAPIHandler+Extension.swift
+//  CatalogAPIHandler+E-Commerce.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension CatalogAPIHandler {

--- a/E_Commerce/Sources/Utility/InjestAPiHandler+Extension.swift
+++ b/E_Commerce/Sources/Utility/InjestAPiHandler+Extension.swift
@@ -5,5 +5,7 @@
 //  Created by khushbu on 29/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation

--- a/E_Commerce/Sources/Utility/MMKVHelper+E-Commerce.swift
+++ b/E_Commerce/Sources/Utility/MMKVHelper+E-Commerce.swift
@@ -1,11 +1,13 @@
 //
-//  MMKVHelper+Extension.swift
+//  MMKVHelper+E-Commerce.swift
 //
 //
 //  Created by khushbu on 29/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension MMKVHelper {

--- a/E_Commerce/Sources/event_Types/CancelType.swift
+++ b/E_Commerce/Sources/event_Types/CancelType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum CancelType: String, Codable, EnumComposable {

--- a/E_Commerce/Sources/event_Types/CartAction.swift
+++ b/E_Commerce/Sources/event_Types/CartAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum CartAction: String, Codable, EnumComposable {

--- a/E_Commerce/Sources/event_Types/DeliveryAction.swift
+++ b/E_Commerce/Sources/event_Types/DeliveryAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 29/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum DeliveryAction: String, EnumComposable {

--- a/E_Commerce/Sources/event_Types/EComItemAction.swift
+++ b/E_Commerce/Sources/event_Types/EComItemAction.swift
@@ -5,10 +5,12 @@
 //  Created by khushbu on 29/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
-public enum ItemAction: String, EnumComposable {
+public enum EComItemAction: String, EnumComposable {
     case impression
     case view
     case detail

--- a/E_Commerce/Sources/event_Types/ItemStockStatus.swift
+++ b/E_Commerce/Sources/event_Types/ItemStockStatus.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 27/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ItemStockStatus: String, EnumComposable {

--- a/E_Commerce/Sources/event_Types/ItemType.swift
+++ b/E_Commerce/Sources/event_Types/ItemType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 27/10/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ItemType: String, EnumComposable {

--- a/E_Commerce/Sources/event_Types/ScanChannel.swift
+++ b/E_Commerce/Sources/event_Types/ScanChannel.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ScanChannel: String, Codable, EnumComposable {

--- a/E_Commerce/Sources/event_Types/ScanType.swift
+++ b/E_Commerce/Sources/event_Types/ScanType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ScanType: String, Codable, EnumComposable {

--- a/E_Commerce/Sources/event_Types/ScheduleDeliveryAction.swift
+++ b/E_Commerce/Sources/event_Types/ScheduleDeliveryAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 01/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ScheduleDeliveryAction: String, Codable, EnumComposable {

--- a/E_Commerce/Sources/event_Types/ShopMode.swift
+++ b/E_Commerce/Sources/event_Types/ShopMode.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ShopMode: String, Codable, EnumComposable {

--- a/E_Commerce/Sources/impression_listener/CfItemImpressionListener.swift
+++ b/E_Commerce/Sources/impression_listener/CfItemImpressionListener.swift
@@ -4,7 +4,9 @@
 //
 //  Created by khushbu on 02/11/23.
 //
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 import UIKit
 

--- a/E_Commerce/Sources/impression_listener/ItemImpressionModel.swift
+++ b/E_Commerce/Sources/impression_listener/ItemImpressionModel.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 
 struct ItemImpressionModel: Codable {
     var itemProperties: ItemModel

--- a/E_Learning/Sources/Builders/CfLogExamEvent.swift
+++ b/E_Learning/Sources/Builders/CfLogExamEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogExamEvent {

--- a/E_Learning/Sources/Builders/CfLogModuleEvent.swift
+++ b/E_Learning/Sources/Builders/CfLogModuleEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogModuleEvent {

--- a/E_Learning/Sources/Builders/CfLogQuestionEvent.swift
+++ b/E_Learning/Sources/Builders/CfLogQuestionEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogQuestionEvent {

--- a/E_Learning/Sources/event_types/ExamAction.swift
+++ b/E_Learning/Sources/event_types/ExamAction.swift
@@ -4,7 +4,9 @@
 //
 //  Created by khushbu on 02/11/23.
 //
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ExamAction: String, EnumComposable {

--- a/E_Learning/Sources/event_types/ModuleLogAction.swift
+++ b/E_Learning/Sources/event_types/ModuleLogAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum ModuleLogAction: String, EnumComposable {

--- a/E_Learning/Sources/event_types/QuestionAction.swift
+++ b/E_Learning/Sources/event_types/QuestionAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum QuestionAction: String, EnumComposable {

--- a/Loyalty/Sources/Builders/CfLogLevelEvent.swift
+++ b/Loyalty/Sources/Builders/CfLogLevelEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogLevelEvent {

--- a/Loyalty/Sources/Builders/CfLogMilestoneEvent.swift
+++ b/Loyalty/Sources/Builders/CfLogMilestoneEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogMilestoneEvent {

--- a/Loyalty/Sources/Builders/CfLogPromoEvent.swift
+++ b/Loyalty/Sources/Builders/CfLogPromoEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogPromoEvent {

--- a/Loyalty/Sources/Builders/CfLogRewardEvent.swift
+++ b/Loyalty/Sources/Builders/CfLogRewardEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogRewardEvent {

--- a/Loyalty/Sources/Builders/CfLogSurveyEvent.swift
+++ b/Loyalty/Sources/Builders/CfLogSurveyEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogSurveyEvent {

--- a/Loyalty/Sources/Catalog/CfLoyaltyCatalog.swift
+++ b/Loyalty/Sources/Catalog/CfLoyaltyCatalog.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum CfLoyaltyCatalog {

--- a/Loyalty/Sources/event_types/MilestoneAction.swift
+++ b/Loyalty/Sources/event_types/MilestoneAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum MilestoneAction: String, EnumComposable {

--- a/Loyalty/Sources/event_types/PromoAction.swift
+++ b/Loyalty/Sources/event_types/PromoAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PromoAction: String, EnumComposable {

--- a/Loyalty/Sources/event_types/PromoItemType.swift
+++ b/Loyalty/Sources/event_types/PromoItemType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 08/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PromoItemType: String, Codable, EnumComposable {

--- a/Loyalty/Sources/event_types/PromoType.swift
+++ b/Loyalty/Sources/event_types/PromoType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PromoType: String, EnumComposable {

--- a/Loyalty/Sources/event_types/RedeemType.swift
+++ b/Loyalty/Sources/event_types/RedeemType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 08/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum RedeemType: String, Codable, EnumComposable {

--- a/Loyalty/Sources/event_types/RewardAction.swift
+++ b/Loyalty/Sources/event_types/RewardAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum RewardAction: String, EnumComposable {

--- a/Loyalty/Sources/event_types/SurveyAction.swift
+++ b/Loyalty/Sources/event_types/SurveyAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 08/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum SurveyAction: String, Codable, EnumComposable {

--- a/Loyalty/Sources/event_types/SurveyType.swift
+++ b/Loyalty/Sources/event_types/SurveyType.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 08/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 import Foundation

--- a/Loyalty/Sources/utils/CFSetup+Loyalty.swift
+++ b/Loyalty/Sources/utils/CFSetup+Loyalty.swift
@@ -1,11 +1,13 @@
 //
-//  CFSetup+Extension.swift
+//  CFSetup+Loyalty.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension CFSetup {

--- a/Loyalty/Sources/utils/CatalogAPIHandler+Loyalty.swift
+++ b/Loyalty/Sources/utils/CatalogAPIHandler+Loyalty.swift
@@ -1,11 +1,13 @@
 //
-//  CatalogAPIHandler+Extension.swift
+//  CatalogAPIHandler+Loyalty.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension CatalogAPIHandler {

--- a/Loyalty/Sources/utils/LoyaltyConstants.swift
+++ b/Loyalty/Sources/utils/LoyaltyConstants.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 07/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 enum LoyaltyConstants {

--- a/Loyalty/Sources/utils/MMKVHelper+Loyalty.swift
+++ b/Loyalty/Sources/utils/MMKVHelper+Loyalty.swift
@@ -1,11 +1,13 @@
 //
-//  MMKVHelper+Extension.swift
+//  MMKVHelper+Loyalty.swift
 //
 //
 //  Created by khushbu on 16/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public extension MMKVHelper {

--- a/Payments/Sources/Builders/CfLogDeferredPaymentEvent.swift
+++ b/Payments/Sources/Builders/CfLogDeferredPaymentEvent.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogDeferredPaymentEvent {

--- a/Payments/Sources/Builders/CfLogPaymentMethodEvent.swift
+++ b/Payments/Sources/Builders/CfLogPaymentMethodEvent.swift
@@ -4,7 +4,9 @@
 //
 //  Created by khushbu on 02/11/23.
 //
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public class CfLogPaymentMethodEvent {

--- a/Payments/Sources/Event_Types/PaymentAction.swift
+++ b/Payments/Sources/Event_Types/PaymentAction.swift
@@ -5,7 +5,9 @@
 //  Created by khushbu on 02/11/23.
 //
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PaymentAction: String, EnumComposable {

--- a/Payments/Sources/Event_Types/PaymentMethod.swift
+++ b/Payments/Sources/Event_Types/PaymentMethod.swift
@@ -4,7 +4,9 @@
 //
 //  Created by khushbu on 02/11/23.
 
+#if canImport(CasualFoundryCore)
 import CasualFoundryCore
+#endif
 import Foundation
 
 public enum PaymentMethod: String, Codable, EnumComposable {


### PR DESCRIPTION
@moizhassankh I needed to change some filenames to avoid duplicates. Otherwise just look into the `CausalFoundrySDK.podspec` file. There you can adjust all you need.
The podspec implementation passed the lint validation.

A how to regarding podspecs can be found here: https://scottlydon.medium.com/convert-your-xcode-project-into-a-cocoapod-with-dependencies-fonts-and-images-3834b71c758a